### PR TITLE
workaround the ugly 'bridge disposed' bug in current LO

### DIFF
--- a/src/pyoocalc.py
+++ b/src/pyoocalc.py
@@ -31,6 +31,7 @@ import time
 # Exceptions
 from com.sun.star.uno import RuntimeException
 from com.sun.star.lang import IllegalArgumentException
+from com.sun.star.lang import DisposedException
 from com.sun.star.connection import NoConnectException
 from com.sun.star.io import IOException
 
@@ -780,6 +781,8 @@ uno:socket,host=localhost,port=2002;urp;StarOffice.ComponentContext",
         except NoConnectException as e:
             waiting = True
             start_office_instance(office)
+        except DisposedException as e:
+            waiting = True
 
         if waiting:
             exception = None
@@ -788,7 +791,7 @@ uno:socket,host=localhost,port=2002;urp;StarOffice.ComponentContext",
                 try:
                     self._init_doc()
                     break
-                except NoConnectException as e:
+                except (NoConnectException, DisposedException) as e:
                     exception = e
                     time.sleep(attempt_period)
             else:


### PR DESCRIPTION
hi,
thanx for this great library.
it helps us turning meaningless, web generated data into meaningful and beautifully colored charts.
the one thing we had to overcome was the "bridge disposed bug" mentioned in https://github.com/dagwieers/unoconv/issues/57
https://forum.openoffice.org/en/forum/viewtopic.php?f=9&t=81117
https://stackoverflow.com/questions/44071990/uno-error-binary-urp-bridge-disposed-during-call

fortunately you did care for similar "no connection" bugs already. that's where we added a few lines.
cheers,
/markus
